### PR TITLE
fix(types): issue with typing for types option

### DIFF
--- a/types/signale.d.ts
+++ b/types/signale.d.ts
@@ -80,7 +80,7 @@ declare namespace _signale {
     scope?: string;
     secrets?: Secret;
     stream?: WritableStream | WritableStream[];
-    types?: Partial<Record<T, LoggerConfiguration>>;
+    types?: Partial<Record<T, Partial<LoggerConfiguration>>>;
   }
 
   export interface Constructor {


### PR DESCRIPTION
Fix types of types option, based on the documentation and source code I can provide not fully described object for types e.g.

```javascript
const {Signale} = require('signale');

const options = {
  types: {
    error: {
      badge: '!!',
      label: 'fatal error'
    },
    success: {
      badge: '++',
      label: 'huge success'
    }
  }
};

const signale = new Signale();
signale.error('Default Error Log');
signale.success('Default Success Log');

const custom = new Signale(options);
custom.error('Custom Error Log');
custom.success('Custom Success Log');
```

or 

```javascript
const {Signale} = require('signale');

const options = {
  types: {
    error: {
      badge: '!!',
      label: 'fatal error'
    },
    success: {
      badge: '++',
      label: 'huge success'
    }
  }
};

const signale = new Signale();
signale.error('Default Error Log');
signale.success('Default Success Log');

const custom = new Signale(options);
custom.error('Custom Error Log');
custom.success('Custom Success Log');
```
In the PR I suggest the fix for typescript types only, the documentation and javascript code continue working as usual. 